### PR TITLE
Update instructions to install using poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is highly encouraged to use [poetry](https://python-poetry.org) for
 maintaining your project's dependencies. Normally autohooks-plugin-black is
 installed as a development dependency.
 
-    poetry install
+    poetry add --dev autohooks-plugin-black
 
 ## Usage
 


### PR DESCRIPTION
**What**:

A minor change to the README to instruct users how to install using `poetry`.

**Why**:

As someone unfamiliar with poetry, it took some research to realize that the `poetry install` command in the README was not actually what I had to run.

**How**:

n/a

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/autohooks-plugin-black/blob/master/CHANGELOG.md) Entry N/A
- [x] Documentation
