### PR TITLE
Fix test for autohooks 22.8.1

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -54,7 +54,6 @@ class AutohooksBlackTestCase(TestCase):
         self.assertTrue(config_path.is_file())
 
         autohooksconfig = load_config_from_pyproject_toml(config_path)
-        self.assertTrue(autohooksconfig.has_config())
 
         black_config = get_black_config(autohooksconfig.get_config())
         self.assertEqual(black_config.get_value("foo"), "bar")


### PR DESCRIPTION
**What**:

Fix test for autohooks 22.8.1

**Why**:

In autohooks 22.8.1 the AutohooksConfig.has_config method has been
removed.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/autohooks-plugin-black/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
