### PR TITLE
Remove: Use default config for conventional commits

### DIFF
--- a/changelog.toml
+++ b/changelog.toml
@@ -1,8 +1,0 @@
-commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
-]
-
-changelog_dir = "changelog"


### PR DESCRIPTION
## What
Use default config for conventional commits

## Why

Remove changelog.toml to use default config for gathering the conventional commits.
